### PR TITLE
fix: mvnw not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,11 @@ WORKDIR /build
 
 COPY .mvn/ ./.mvn
 COPY mvnw pom.xml  ./
+RUN sed -i 's/\r$//' mvnw
 RUN ./mvnw dependency:go-offline
 
 COPY . .
+RUN sed -i 's/\r$//' mvnw
 RUN ./mvnw package -DskipTests
 
 FROM eclipse-temurin:17-jdk-alpine


### PR DESCRIPTION
mvnw có kết thúc dòng bằng ký tự Windows CRLF (\r\n) thay vì ký tự Unix LF (\n). Nên khi chạy sẽ bị báo ".mvnw not found"